### PR TITLE
Remove specification version for github repo

### DIFF
--- a/twitter-bootswatch-rails-helpers.gemspec
+++ b/twitter-bootswatch-rails-helpers.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency     'twitter-bootswatch-rails', '~> 3.3', '>= 3.3.2'
+  gem.add_dependency 'twitter-bootswatch-rails'
 
 end


### PR DESCRIPTION
### what is this

First, we want to remove this repo from our product Gem due to substancial EOL.

Before that, we must upgrade rails 5x, and having dependency hell.
We decided fork two repo under our org.

### problem
to reproduce problem, just bundle after Gemfile like this.
```
gem 'twitter-bootswatch-rails', github: 'knowledgelabo/twitter-bootswatch-rails', tag: 'v3.1.1.1'
gem 'twitter-bootswatch-rails-helpers', github: 'knowledgelabo/twitter-bootswatch-rails-helpers'
```
when `bundle`, it goes
```
Bundler could not find compatible versions for gem "twitter-bootswatch-rails":
  In Gemfile:
    twitter-bootswatch-rails

    twitter-bootswatch-rails-helpers was resolved to 3.3.2.0, which depends on
      twitter-bootswatch-rails (~> 3.3, >= 3.3.2)

Could not find gem 'twitter-bootswatch-rails (~> 3.3, >= 3.3.2)', which is required by gem 'twitter-bootswatch-rails-helpers', in any of the relevant sources:
  https://github.com/knowledgelabo/twitter-bootswatch-rails.git (at v3.1.1.1@27e1ac0)
```

So we forked to enable bundle like this
```
gem 'twitter-bootswatch-rails', github: 'knowledgelabo/twitter-bootswatch-rails', tag: 'v3.1.1.1'
gem 'twitter-bootswatch-rails-helpers', github: 'knowledgelabo/twitter-bootswatch-rails-helpers', tag: 'kl-fix'
```

